### PR TITLE
Add support for sending null values and resolving namespace values

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,19 +154,24 @@ It is strongly recommended to leave the Password and User fields empty.
             "fieldMappings": [
                 {
                     "fieldName": "Id",
-                    "order": 1
+                    "order": 1,
+                    "dataType": "VARCHAR(100)",
+                    "resolveNamespace": true
                 },
                 {
                     "fieldName": "Name",
-                    "order": 2
+                    "order": 2,
+                    "dataType": "VARCHAR(100)"
                 },
                 {
                     "fieldName": "secretData",
-                    "order": 3
+                    "order": 3,
+                    "dataType": "VARCHAR(100)"
                 }
             ],
             "query": "mssql",
             "tableName": "Customers",
+            "nullEmptyColumnValues": true,
             "idColumn": "Id"
         }],
     "tableMappings": [
@@ -278,7 +283,7 @@ The server config is used to set up the connection to the database server.
 
 ### PostMapping config
 
-PostMapping writes single datasets from the datahub to a table. This includes INSERT, UPDATE (via MERGE) and DELETE. 
+PostMapping writes single datasets from the datahub to a table. This includes INSERT, UPDATE (via MERGE) and DELETE.
 
 NB! Posting to a table requires you to make use of the 'latest' feature in the datahub. This makes sure that we only have one occurance of any given entity in any give batch. This is important to not have issues where an entity could be created and deleted in the same batch, or changed and the deleted etc.
 
@@ -300,6 +305,8 @@ NB! Posting to a table requires you to make use of the 'latest' feature in the d
 
 `query` Can either be a query to insert to a column with or without the PK in the dataset. If the PK is auto-incrementing we cannot do deletes on that table.
 
+`nullEmptyColumnValues` if true, the datalayer will set null values for fields not included in the payload. To determine the correct null type, the `datatype` for each column must be defined on the field config.
+
 `idColumn` specifies which property that contains the primary key for the table, if the table has an auto-incrementing PK, this field should be left empty.
 
 `fieldMappings` list of columns, in order, that will be written to the table
@@ -313,15 +320,19 @@ The FieldMapping adds order to the data that will be written to the table. If no
     "fieldMappings": [
                 {
                     "fieldName": "Id",
-                    "order": 1
+                    "order": 1,
+                    "dataType": "VARCHAR(100)",
+                    "resolveNamespace": true
                 },
                 {
                     "fieldName": "Name",
-                    "order": 2
+                    "order": 2,
+                    "dataType": "VARCHAR(100)"
                 },
                 {
                     "fieldName": "secretData",
-                    "order": 3
+                    "order": 3,
+                    "dataType": "VARCHAR(100)"
                 }
             ]
 }
@@ -330,6 +341,10 @@ The FieldMapping adds order to the data that will be written to the table. If no
 `fieldName` is the name of the property in the dataset
 
 `order` is in what order it should be written in to the table
+
+`datatype` is the type defined for the matching table column
+
+`resolveNamespace` if true, this will resolve any namespace ref prefix to a full uri
 
 We use could use this to specify if we want to write the property to the database or not.
 
@@ -524,6 +539,6 @@ in Docker. This will most likelly be changed in the future, and you should use E
 
 ## Known issues
 
-The driver does not handle the datetime format `2022-01-01T01:01:01 +01:00` it needs to get the date like this `2022-01-01T00:01:01Z` or `2022-01-01T00:01:01.555` 
+The driver does not handle the datetime format `2022-01-01T01:01:01 +01:00` it needs to get the date like this `2022-01-01T00:01:01Z` or `2022-01-01T00:01:01.555`
 
 The integer datatype is not handled when writing to a table, this is because all numbers are treated as float64 by the datahub.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/juliangruber/go-intersect v1.1.0
 	github.com/labstack/echo/v4 v4.9.0
+	github.com/mimiro-io/internal-go-util v0.0.0-20220621120333-ed6ba3a9996d
 	github.com/onsi/gomega v1.20.0
 	github.com/spf13/viper v1.13.0
 	go.uber.org/fx v1.18.1

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/goveralls v0.0.6/go.mod h1:h8b4ow6FxSPMQHF6o2ve3qsclnffZjYTNEKmLesRwqw=
+github.com/mimiro-io/internal-go-util v0.0.0-20220621120333-ed6ba3a9996d h1:ewKs+e5AH5HASWsJzKrFfyVKANadJKpsS4Rtp2UNXBM=
+github.com/mimiro-io/internal-go-util v0.0.0-20220621120333-ed6ba3a9996d/go.mod h1:SLB+uPhL3Lf0EsTnVEiyMq2TB7od0ro1tfog/y/eOHE=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -57,7 +57,7 @@ type FieldMapping struct {
 	FieldName        string `json:"fieldName"`
 	SortOrder        int    `json:"order"`
 	ResolveNamespace bool   `json:"resolveNamespace"`
-	Datatype         string `json:"datatype"`
+	DataType         string `json:"dataType"`
 }
 
 type TableConfig struct {

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -55,9 +55,7 @@ type PostMapping struct {
 
 type FieldMapping struct {
 	FieldName        string `json:"fieldName"`
-	ToSqlField       string `json:"toSqlField"`
 	SortOrder        int    `json:"order"`
-	Type             string `json:"type"`
 	ResolveNamespace bool   `json:"resolveNamespace"`
 	Datatype         string `json:"datatype"`
 }

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -44,19 +44,22 @@ type ColumnMapping struct {
 }
 
 type PostMapping struct {
-	DatasetName   string          `json:"datasetName"`
-	TableName     string          `json:"tableName"`
-	IdColumn      string          `json:"idColumn"`
-	Query         string          `json:"query"`
-	Config        *TableConfig    `json:"config"`
-	FieldMappings []*FieldMapping `json:"fieldMappings"`
+	DatasetName           string          `json:"datasetName"`
+	TableName             string          `json:"tableName"`
+	IdColumn              string          `json:"idColumn"`
+	Query                 string          `json:"query"`
+	Config                *TableConfig    `json:"config"`
+	FieldMappings         []*FieldMapping `json:"fieldMappings"`
+	NullEmptyColumnValues bool            `json:"nullEmptyColumnValues"`
 }
 
 type FieldMapping struct {
-	FieldName  string `json:"fieldName"`
-	ToSqlField string `json:"toSqlField"`
-	SortOrder  int    `json:"order"`
-	Type       string `json:"type"`
+	FieldName        string `json:"fieldName"`
+	ToSqlField       string `json:"toSqlField"`
+	SortOrder        int    `json:"order"`
+	Type             string `json:"type"`
+	ResolveNamespace bool   `json:"resolveNamespace"`
+	Datatype         string `json:"datatype"`
 }
 
 type TableConfig struct {

--- a/internal/layers/postlayer.go
+++ b/internal/layers/postlayer.go
@@ -137,7 +137,7 @@ func (postLayer *PostLayer) execQuery(entities []*Entity, query string, fields [
 
 				args[i] = value
 
-				datatype := strings.Split(field.Datatype, "(")[0]
+				datatype := strings.Split(field.DataType, "(")[0]
 				if value == nil {
 					if !postLayer.PostRepo.postTableDef.NullEmptyColumnValues {
 						continue // TODO:Need to fail properly when this happens

--- a/internal/web/datasethandler.go
+++ b/internal/web/datasethandler.go
@@ -10,18 +10,12 @@ import (
 	"go.uber.org/zap"
 	"net/http"
 	"net/url"
-	"sort"
 	"strconv"
 )
 
 type ServiceInfo struct {
 	Name     string
 	Location string
-}
-
-type DatasetName struct {
-	Name string   `json:"name"`
-	Type []string `json:"type"`
 }
 
 type datasetHandler struct {
@@ -51,14 +45,12 @@ func NewDatasetHandler(lc fx.Lifecycle, e *echo.Echo, logger *zap.SugaredLogger,
 
 // listDatasetsHandler
 func (handler *datasetHandler) listDatasetsHandler(c echo.Context) error {
-	names := make([]DatasetName, 0)
-	datasets := handler.layer.GetDatasetNames()
-	sort.Strings(datasets)
-	for _, v := range datasets {
-		names = append(names, DatasetName{Name: v, Type: []string{"GET"}})
-	}
+	datasets := handler.layer.GetDatasetEndpoints()
+	//sort.Slice(datasets, func(i, j int) bool {
+	//	return datasets[i].Name < datasets[j].Name
+	//})
 
-	return c.JSON(http.StatusOK, names)
+	return c.JSON(http.StatusOK, datasets)
 }
 
 // getEntitiesHandler


### PR DESCRIPTION
* `"nullEmptyColumnValues": true` now allows you to set null values in the table for fields not present in the entity payload.
* `"resolveNamespace": true` can now be used in a field mapping to resolve the namespace ref in a value into a full uri.