### PR TITLE
feature-27: Added upsertBulk

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ It is strongly recommended to leave the Password and User fields empty.
                     "dataType": "VARCHAR(100)"
                 }
             ],
-            "query": "mssql",
+            "query": "'upsertBulk' or user-defined sql statement",
             "tableName": "Customers",
             "nullEmptyColumnValues": true,
             "idColumn": "Id"
@@ -285,7 +285,7 @@ The server config is used to set up the connection to the database server.
 
 PostMapping writes single datasets from the datahub to a table. This includes INSERT, UPDATE (via MERGE) and DELETE.
 
-NB! Posting to a table requires you to make use of the 'latest' feature in the datahub. This makes sure that we only have one occurance of any given entity in any give batch. This is important to not have issues where an entity could be created and deleted in the same batch, or changed and the deleted etc.
+NB! Posting to a table requires you to make use of the 'latestOnly' feature in the datahub. This makes sure that we only have one occurance of any given entity in any given batch. This is important to not have issues where an entity could be created and deleted in the same batch, or changed and the deleted etc.
 
 ```json
 [
@@ -303,7 +303,7 @@ NB! Posting to a table requires you to make use of the 'latest' feature in the d
 
 `tableName` name of the table in the database
 
-`query` Can either be a query to insert to a column with or without the PK in the dataset. If the PK is auto-incrementing we cannot do deletes on that table.
+`query` Can either be a 'upsertBulk' or a user-defined query to insert to a table with or without the PK in the dataset. If the PK is auto-incrementing we cannot do deletes on that table. the keyword 'upsertBulk' is a lot faster and should be considered default if the requirements are nothing special.
 
 `nullEmptyColumnValues` if true, the datalayer will set null values for fields not included in the payload. To determine the correct null type, the `datatype` for each column must be defined on the field config.
 
@@ -342,7 +342,7 @@ The FieldMapping adds order to the data that will be written to the table. If no
 
 `order` is in what order it should be written in to the table
 
-`datatype` is the type defined for the matching table column
+`dataType` is the type defined for the matching table column
 
 `resolveNamespace` if true, this will resolve any namespace ref prefix to a full uri
 
@@ -541,4 +541,4 @@ in Docker. This will most likelly be changed in the future, and you should use E
 
 The driver does not handle the datetime format `2022-01-01T01:01:01 +01:00` it needs to get the date like this `2022-01-01T00:01:01Z` or `2022-01-01T00:01:01.555`
 
-The integer datatype is not handled when writing to a table, this is because all numbers are treated as float64 by the datahub.
+FIXED: The integer datatype is not handled when writing to a table, this is because all numbers are treated as float64 by the datahub.

--- a/internal/layers/postlayer.go
+++ b/internal/layers/postlayer.go
@@ -8,16 +8,19 @@ import (
 	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/mimiro-io/internal-go-util/pkg/uda"
 	"github.com/mimiro-io/mssqldatalayer/internal/conf"
+	"github.com/spf13/cast"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
 )
 
 type PostLayer struct {
 	cmgr     *conf.ConfigurationManager //
 	logger   *zap.SugaredLogger
-	PostRepo *PostRepository //exported because it needs to deferred from main??
+	PostRepo *PostRepository
 }
 type PostRepository struct {
 	DB            *sql.DB
@@ -88,9 +91,7 @@ func (postLayer *PostLayer) PostEntities(datasetName string, entities []*Entity,
 		postLayer.logger.Errorf("Please add query in config for %s in ", datasetName)
 		return errors.New(fmt.Sprintf("no query found in config for dataset: %s", datasetName))
 	}
-	postLayer.logger.Debug(query)
-
-	queryDel := fmt.Sprintf(`DELETE FROM %s WHERE %s =`, strings.ToLower(postLayer.PostRepo.postTableDef.TableName), postLayer.PostRepo.postTableDef.IdColumn)
+	queryDel := fmt.Sprintf(`DELETE FROM %s WHERE %s =`, postLayer.PostRepo.postTableDef.TableName, postLayer.PostRepo.postTableDef.IdColumn)
 
 	fields := postLayer.PostRepo.postTableDef.FieldMappings
 
@@ -113,16 +114,36 @@ func (postLayer *PostLayer) PostEntities(datasetName string, entities []*Entity,
 			return fields[i].SortOrder < fields[j].SortOrder
 		})
 	}
+	if query == "upsertBulk" {
+		// create 20 paralell inserts 500 entitites each
+		groupCount := 20
+		var wg sync.WaitGroup
+		for i := 0; i < groupCount; i++ {
+			wg.Add(1)
 
-	return postLayer.execQuery(entities, query, fields, queryDel)
+			entslice := entities[len(entities)/groupCount*i : ((len(entities)/groupCount*i)+len(entities)/groupCount)-1]
+
+			go func(slice []*Entity) {
+				defer wg.Done()
+				postLayer.upsertBulk(slice, fields, queryDel)
+
+			}(entslice)
+		}
+		wg.Wait()
+		return nil
+
+	} else {
+		return postLayer.execQuery(entities, query, fields, queryDel)
+	}
 }
 func (postLayer *PostLayer) execQuery(entities []*Entity, query string, fields []*conf.FieldMapping, queryDel string) error {
+	rowId := ""
 	for _, post := range entities {
+		s := post.StripProps()
 		if !strings.ContainsAny(post.ID, ":") {
 			continue
 		}
 		if !post.IsDeleted { //If is deleted True --> Delete from table
-			s := post.StripProps()
 			args := make([]interface{}, len(fields))
 			columnValues := make([]any, 0)
 			for i, field := range fields {
@@ -151,7 +172,7 @@ func (postLayer *PostLayer) execQuery(entities []*Entity, query string, fields [
 							bit = 1
 						}
 						columnValues = append(columnValues, bit)
-					case "INT", "SMALLINT", "TINYINT":
+					case "INT", "SMALLINT", "TINYINT", "INTEGER":
 						columnValues = append(columnValues, int64(value.(float64)))
 					case "FLOAT":
 						columnValues = append(columnValues, fmt.Sprintf("%f", value))
@@ -165,7 +186,37 @@ func (postLayer *PostLayer) execQuery(entities []*Entity, query string, fields [
 				postLayer.logger.Error(err)
 				return err
 			}
-		} else if postLayer.PostRepo.postTableDef.IdColumn != "" {
+		} else {
+			for _, field := range fields {
+				var value interface{}
+
+				propValue := s[field.FieldName]
+				if field.ResolveNamespace && propValue != nil {
+					value = uda.ToURI(postLayer.PostRepo.EntityContext, s[field.FieldName].(string))
+				} else {
+					value = propValue
+				}
+				datatype := strings.Split(field.DataType, "(")[0]
+
+				if field.FieldName == postLayer.PostRepo.postTableDef.IdColumn {
+					switch datatype {
+					case "BIT":
+						bit := false
+						if value.(bool) {
+							bit = true
+						}
+						rowId += strconv.FormatBool(bit)
+					case "INT", "SMALLINT", "TINYINT", "INTEGER":
+						rowId += strconv.FormatInt(cast.ToInt64(value.(float64)), 10)
+					case "FLOAT":
+						rowId += fmt.Sprintf("%f", value)
+					default: // all other types can be sent as string
+						rowId += fmt.Sprintf("%s", value)
+					}
+				}
+			}
+
+			queryDel += queryDel + rowId + ";"
 			_, err := postLayer.PostRepo.DB.Exec(queryDel)
 			if err != nil {
 				postLayer.logger.Error(err)
@@ -174,6 +225,206 @@ func (postLayer *PostLayer) execQuery(entities []*Entity, query string, fields [
 	}
 	return nil
 }
+
+func (postLayer *PostLayer) upsertBulk(entities []*Entity, fields []*conf.FieldMapping, queryDel string) error {
+	tx, err := postLayer.PostRepo.DB.Begin()
+	if err != nil {
+		return err
+	}
+	txOK := false
+	defer func() {
+		if !txOK {
+			tx.Rollback()
+		}
+	}()
+	buildQuery := ""
+	for _, post := range entities {
+		if !strings.ContainsAny(post.ID, ":") {
+			continue
+		}
+
+		s := post.StripProps()
+		args := make([]interface{}, len(fields))
+		columnNames := ""
+		columnValues := ""
+		rowId := ""
+		InsertColumnNamesValues := ""
+		if !post.IsDeleted { //If is deleted True --> Do not store
+			buildQuery += fmt.Sprintf("DELETE FROM %s WHERE %s= %s", postLayer.PostRepo.postTableDef.TableName, postLayer.PostRepo.postTableDef.IdColumn, strings.Split(post.ID, ":")[1])
+			buildQuery += ";"
+			buildQuery += fmt.Sprintf("INSERT INTO %s values (", strings.ToLower(postLayer.PostRepo.postTableDef.TableName))
+			for i, field := range fields {
+				var value interface{}
+
+				propValue := s[field.FieldName]
+				if field.ResolveNamespace && propValue != nil {
+					value = uda.ToURI(postLayer.PostRepo.EntityContext, s[field.FieldName].(string))
+				} else {
+					value = propValue
+				}
+				args[i] = value
+				datatype := strings.Split(field.DataType, "(")[0]
+				if value == nil {
+					if !postLayer.PostRepo.postTableDef.NullEmptyColumnValues {
+						continue // TODO:Need to fail properly when this happens
+					}
+					columnValues += cast.ToString(getSqlNull(datatype))
+				} else {
+					switch datatype {
+					case "BIT":
+						bit := false
+						if value.(bool) {
+							bit = true
+						}
+						columnValues += strconv.FormatBool(bit) + ","
+					case "INT", "SMALLINT", "TINYINT", "INTEGER":
+						columnValues += strconv.FormatInt(cast.ToInt64(value.(float64)), 10) + ","
+					case "FLOAT":
+						columnValues += fmt.Sprintf("%f,", value)
+					default: // all other types can be sent as string
+						columnValues += fmt.Sprintf("'%s',", value)
+					}
+				}
+				if field.FieldName == postLayer.PostRepo.postTableDef.IdColumn {
+					rowId = strings.TrimRight(columnValues, ",")
+				}
+				columnNames += fmt.Sprintf("%s,", field.FieldName)
+				InsertColumnNamesValues += fmt.Sprintf("%s = source.%s, ", field.FieldName, field.FieldName)
+
+			}
+			columnNames = columnNames[:len(columnNames)-1]
+			columnValues = columnValues[:len(columnValues)-1]
+			InsertColumnNamesValues = strings.TrimRight(InsertColumnNamesValues, ", ")
+			buildQuery += columnValues + ");"
+		} else {
+			for _, field := range fields {
+				var value interface{}
+
+				propValue := s[field.FieldName]
+				if field.ResolveNamespace && propValue != nil {
+					value = uda.ToURI(postLayer.PostRepo.EntityContext, s[field.FieldName].(string))
+				} else {
+					value = propValue
+				}
+				datatype := strings.Split(field.DataType, "(")[0]
+
+				if field.FieldName == postLayer.PostRepo.postTableDef.IdColumn {
+					switch datatype {
+					case "BIT":
+						bit := false
+						if value.(bool) {
+							bit = true
+						}
+						rowId += strconv.FormatBool(bit)
+					case "INT", "SMALLINT", "TINYINT", "INTEGER":
+						rowId += strconv.FormatInt(cast.ToInt64(value.(float64)), 10)
+					case "FLOAT":
+						rowId += fmt.Sprintf("%f", value)
+					default: // all other types can be sent as string
+						rowId += fmt.Sprintf("%s", value)
+					}
+				}
+			}
+			buildQuery += queryDel + rowId + ";"
+		}
+	}
+	_, err = tx.Exec(buildQuery)
+
+	if err != nil {
+		return err
+	}
+	tx.Commit()
+	return nil
+}
+
+// TODO: Implement prepared statement for nullEmptyColumnValues = true
+/*func (postLayer *PostLayer) upsertBulk2(entities []*Entity, query string, fields []*conf.FieldMapping, queryDel string) error {
+	tx, err := postLayer.PostRepo.DB.Begin()
+	if err != nil {
+		return err
+	}
+	txOK := false
+	defer func() {
+		if !txOK {
+			tx.Rollback()
+		}
+	}()
+	//buildQuery := ""
+	columnNames := make([]string, 0)
+	columnValues := make([]interface{}, 0)
+	insertColumnNames := ""
+	for _, post := range entities {
+		if !strings.ContainsAny(post.ID, ":") {
+			continue
+		}
+
+		s := post.StripProps()
+
+		//rowId := ""
+		//InsertColumnNamesValues := ""
+		if !post.IsDeleted { //If is deleted True --> Do not store
+			//buildQuery += fmt.Sprintf("DELETE FROM %s WHERE %s= %s", postLayer.PostRepo.postTableDef.TableName, postLayer.PostRepo.postTableDef.IdColumn, strings.Split(post.ID, ":")[1])
+			//buildQuery += ";"
+			//buildQuery += fmt.Sprintf("INSERT INTO %s values (", strings.ToLower(postLayer.PostRepo.postTableDef.TableName))
+			for _, field := range fields {
+				var value interface{}
+
+				propValue := s[field.FieldName]
+				if field.ResolveNamespace && propValue != nil {
+					value = uda.ToURI(postLayer.PostRepo.EntityContext, s[field.FieldName].(string))
+				} else {
+					value = propValue
+				}
+				datatype := strings.Split(field.DataType, "(")[0]
+				if value == nil {
+					if !postLayer.PostRepo.postTableDef.NullEmptyColumnValues {
+						continue // TODO:Need to fail properly when this happens
+					}
+					columnValues = append(columnValues, cast.ToString(getSqlNull(datatype)))
+				} else {
+					switch datatype {
+					case "BIT":
+						bit := 0
+						if value.(bool) {
+							bit = 1
+						}
+						columnValues = append(columnValues, bit)
+					case "INT", "SMALLINT", "TINYINT", "INTEGER":
+						columnValues = append(columnValues, int64(value.(float64)))
+					case "FLOAT":
+						columnValues = append(columnValues, fmt.Sprintf("%f,", value))
+					default: // all other types can be sent as string
+						columnValues = append(columnValues, fmt.Sprintf("'%s',", value))
+					}
+				}
+				columnNames = append(columnNames, field.FieldName)
+				insertColumnNames += "("
+				insertColumnNames += "@p" + field.FieldName + ","
+
+			}
+			insertColumnNames += strings.TrimRight(insertColumnNames, ",")
+			insertColumnNames += ")"
+			//buildQuery += columnValues + ");"
+
+		} else {
+			for _, field := range fields {
+				if field.FieldName == postLayer.PostRepo.postTableDef.IdColumn {
+					//rowId = fmt.Sprintf("%s", s[field.FieldName])
+				}
+			}
+			//buildQuery += queryDel + rowId + ";"
+		}
+	}
+	stmt := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s", postLayer.PostRepo.postTableDef.TableName,
+		strings.Join(columnNames, ","), insertColumnNames)
+	_, err = tx.Exec(stmt, columnValues...)
+
+	if err != nil {
+		return err
+	}
+	tx.Commit()
+	return nil
+}*/
 
 func getSqlNull(datatype string) any {
 	switch datatype {

--- a/internal/web/posthandler.go
+++ b/internal/web/posthandler.go
@@ -42,8 +42,9 @@ func (handler *postHandler) postHandler(c echo.Context) error {
 	handler.logger.Debugf("Working on dataset %s", datasetName)
 
 	postLayer := handler.postLayer
-
-	batchSize := 1000
+	//set batch size to default batch size of data hub
+	//TODO: Get this as a configurable variable and document usage.
+	batchSize := 10000
 	read := 0
 
 	entities := make([]*layers.Entity, 0) //why 0?


### PR DESCRIPTION
closes  Add batchInsert #27 
upsertBulk uses go routines to split batches in 20 smaller batches and execute inserts in paralell. 
 
Alsoi fixed the delete statement so that it now works for all datatypes