### PR TITLE
Create conn for each go routine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN go test ./... -v
 FROM alpine:latest
 
 RUN apk --no-cache add ca-certificates
+#Fix vulnerability CVE-2023-2650
+RUN apk update && apk add --upgrade libcrypto3 libssl3
 
 WORKDIR /root/
 


### PR DESCRIPTION
This solves the issue of a connection sometimes running with incorrect tableconfig. Prevents the restarts we see in the layer.