### PR TITLE
Bug/53/layer doesnt handle errors when iterating over result sets

### DIFF
--- a/internal/layers/postlayer.go
+++ b/internal/layers/postlayer.go
@@ -5,6 +5,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	_ "time/tzdata"
+
 	_ "github.com/microsoft/go-mssqldb"
 	mssql "github.com/microsoft/go-mssqldb"
 	"github.com/mimiro-io/internal-go-util/pkg/uda"
@@ -12,12 +19,6 @@ import (
 	"github.com/spf13/cast"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"log"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
-	_ "time/tzdata"
 )
 
 type PostLayer struct {
@@ -116,7 +117,6 @@ func (postLayer *PostLayer) PostEntities(datasetName string, entities []*Entity,
 	} else {
 		return postLayer.CustomQuery(entities, query, fields, queryDel)
 	}
-	return nil
 }
 
 func (postLayer *PostLayer) CustomQuery(entities []*Entity, query string, fields []*conf.FieldMapping, queryDel string) error {

--- a/internal/web/datasethandler.go
+++ b/internal/web/datasethandler.go
@@ -3,14 +3,15 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+
 	"github.com/labstack/echo/v4"
 	"github.com/mimiro-io/mssqldatalayer/internal/db"
 	"github.com/mimiro-io/mssqldatalayer/internal/layers"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"net/http"
-	"net/url"
-	"strconv"
 )
 
 type ServiceInfo struct {
@@ -165,18 +166,12 @@ func (handler *datasetHandler) getChangesHandler(c echo.Context) error {
 	})
 
 	if err != nil {
+		// dont write the closing bracket and imply to the client through this that the stream is broken
 		handler.logger.Warn(err)
+	} else {
+		c.Response().Write([]byte("]"))
+		c.Response().Flush()
 	}
 
-	/*entity := map[string]interface{}{
-		"id":    "@continuation",
-		"token": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%o", time.Now().Unix()))),
-	}
-
-	c.Response().Write([]byte(","))
-	_ = enc.Encode(entity)*/
-	c.Response().Write([]byte("]"))
-	c.Response().Flush()
 	return nil
-
 }


### PR DESCRIPTION
Fixed: Layer doesnt handle errors when iterating over result sets
Issue: 53

Issue was in both the low level layer and the upper web handler. The next() call was being checked for an error condition but that error was not being propagated back up. 

At the web handler level the error from reading data was not being actioned, other than being logged. Fixed now so the JSON stream is invalid. Far from ideal but should cause a JSON validating client to error and the request to be resent.
