### PR TITLE
harden parsing of datetime

### DIFF
--- a/internal/layers/postlayer.go
+++ b/internal/layers/postlayer.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -132,11 +131,20 @@ func (postLayer *PostLayer) CustomQuery(entities []*Entity, query string, fields
 		timeZone := postLayer.PostRepo.PostTableDef.TimeZone
 		// put deleted in to own queue that fires at the end of batch.
 		if post.IsDeleted {
-			delQueue += postLayer.CustomDelete(post, fields, s, rowId, timeZone, queryDel)
+			del, err := postLayer.CustomDelete(post, fields, s, rowId, timeZone, queryDel)
+			if err != nil {
+				postLayer.logger.Error(err)
+				return err
+			}
+			delQueue += del
 		} else {
-			payloadValues := postLayer.CreatePayload(post, fields)
+			payloadValues, err := postLayer.CreatePayload(post, fields)
+			if err != nil {
+				postLayer.logger.Error(err)
+				return err
+			}
 			postLayer.logger.Debug(payloadValues)
-			_, err := postLayer.PostRepo.DB.Exec(query, payloadValues...)
+			_, err = postLayer.PostRepo.DB.Exec(query, payloadValues...)
 			if err != nil {
 				postLayer.logger.Error(err)
 				return err
@@ -151,11 +159,15 @@ func (postLayer *PostLayer) CustomQuery(entities []*Entity, query string, fields
 	return nil
 }
 
-func (postLayer *PostLayer) CustomDelete(post *Entity, fields []*conf.FieldMapping, s map[string]interface{}, rowId string, timeZone string, queryDel string) string {
+func (postLayer *PostLayer) CustomDelete(post *Entity, fields []*conf.FieldMapping, s map[string]interface{}, rowId string, timeZone string, queryDel string) (string, error) {
 	delQueue := ""
 	if postLayer.PostRepo.PostTableDef.IdColumn == "" {
 		postLayer.logger.Warn(fmt.Sprintf("Cannot delete entitywhere Id-column is not specified:\t %s", post.ID))
 	} else {
+		location, err := loadLocation(timeZone)
+		if err != nil {
+			return "", err
+		}
 		for _, field := range fields {
 			var value interface{}
 
@@ -181,16 +193,14 @@ func (postLayer *PostLayer) CustomDelete(post *Entity, fields []*conf.FieldMappi
 					rowId += fmt.Sprintf("%f", value)
 				case "DATETIME", "DATETIME2":
 					t, err := time.Parse(time.RFC3339, fmt.Sprintf("%s", value))
-					var location *time.Location
-					location, _ = time.LoadLocation(timeZone)
 					if err != nil {
-						log.Fatal("Couldn't parse datetime")
+						return "", parseError(field.FieldName, datatype, value, post.ID, err)
 					}
 					rowId += fmt.Sprintf("%s", t.In(location))
 				case "DATETIMEOFFSET":
 					t, err := time.Parse(time.RFC3339, fmt.Sprintf("%s", value))
 					if err != nil {
-						log.Fatal("Couldn't parse datetime")
+						return "", parseError(field.FieldName, datatype, value, post.ID, err)
 					}
 					rowId += fmt.Sprintf("%s", t)
 				default: // all other types can be sent as string
@@ -200,13 +210,16 @@ func (postLayer *PostLayer) CustomDelete(post *Entity, fields []*conf.FieldMappi
 		}
 		delQueue += queryDel + rowId + ";"
 	}
-	return delQueue
+	return delQueue, nil
 }
 
 func (postLayer *PostLayer) UpsertBulk(entities []*Entity, fields []*conf.FieldMapping, queryDel string, idColumn string, timeZone string, tableName string) error {
-	buildQuery := postLayer.CreateUpsertBulk(entities, fields, queryDel, idColumn, timeZone, tableName)
-	if buildQuery == "" {
-		return fmt.Errorf("could not resolve datetime, error in creating stmt")
+	buildQuery, err := postLayer.CreateUpsertBulk(entities, fields, queryDel, idColumn, timeZone, tableName)
+	if err != nil {
+		return err
+	}
+	if buildQuery == "" { // every entity in the batch was skipped, nothing to execute
+		return nil
 	}
 	conn, err := postLayer.PostRepo.DB.Conn(postLayer.PostRepo.ctx)
 	if conn == nil {
@@ -238,9 +251,13 @@ func (postLayer *PostLayer) UpsertBulk(entities []*Entity, fields []*conf.FieldM
 
 // TODO: Implement prepared statement for nullEmptyColumnValues = true
 
-func (postLayer *PostLayer) CreatePayload(post *Entity, fields []*conf.FieldMapping) []interface{} {
+func (postLayer *PostLayer) CreatePayload(post *Entity, fields []*conf.FieldMapping) ([]interface{}, error) {
 	s := post.StripProps()
 	timeZone := postLayer.PostRepo.PostTableDef.TimeZone
+	location, err := loadLocation(timeZone)
+	if err != nil {
+		return nil, err
+	}
 	args := make([]interface{}, len(fields))
 	columnValues := make([]any, 0)
 	for i, field := range fields {
@@ -273,25 +290,60 @@ func (postLayer *PostLayer) CreatePayload(post *Entity, fields []*conf.FieldMapp
 				columnValues = append(columnValues, fmt.Sprintf("%f", value))
 			case "DATETIME", "DATETIME2":
 				t, err := time.Parse(time.RFC3339, fmt.Sprintf("%s", value))
-				var location *time.Location
-				location, _ = time.LoadLocation(timeZone)
 				if err != nil {
-					log.Fatal(err)
+					return nil, parseError(field.FieldName, datatype, value, post.ID, err)
 				}
-				columnValues = append(columnValues, t.In(location))
+				ts := t.In(location)
+				if !datetimeInRange(datatype, ts) {
+					postLayer.warnOutOfRange(field.FieldName, datatype, value, post.ID)
+					columnValues = append(columnValues, sql.NullTime{})
+				} else {
+					columnValues = append(columnValues, ts)
+				}
 			case "DATETIMEOFFSET":
 				t, err := time.Parse(time.RFC3339, fmt.Sprintf("%s", value))
-				r := mssql.DateTimeOffset(t)
 				if err != nil {
-					log.Fatal(err)
+					return nil, parseError(field.FieldName, datatype, value, post.ID, err)
 				}
-				columnValues = append(columnValues, r)
+				columnValues = append(columnValues, mssql.DateTimeOffset(t))
 			default: // all other types can be sent as string
 				columnValues = append(columnValues, fmt.Sprintf("%s", value))
 			}
 		}
 	}
-	return columnValues
+	return columnValues, nil
+}
+
+// loadLocation resolves the configured timezone. LoadLocation hands back a nil *Location for an
+// unknown zone and Time.In panics on that, so the error has to be surfaced rather than dropped.
+func loadLocation(timeZone string) (*time.Location, error) {
+	location, err := time.LoadLocation(timeZone)
+	if err != nil {
+		return nil, fmt.Errorf("unknown timezone %q in post mapping: %w", timeZone, err)
+	}
+	return location, nil
+}
+
+func parseError(fieldName string, datatype string, value interface{}, entityID string, err error) error {
+	return fmt.Errorf("could not parse %s value %v for column %s of entity %s: %w", datatype, value, fieldName, entityID, err)
+}
+
+// datetimeInRange reports whether t fits the target column type. SQL Server's legacy DATETIME only
+// reaches back to 1753-01-01 while DATETIME2 starts at 0001-01-01; both stop at 9999-12-31. A value
+// outside the range makes the server reject the whole batch, so callers write NULL instead.
+func datetimeInRange(datatype string, t time.Time) bool {
+	minYear := 1
+	if datatype == "DATETIME" {
+		minYear = 1753
+	}
+	return t.Year() >= minYear && t.Year() <= 9999
+}
+
+func (postLayer *PostLayer) warnOutOfRange(fieldName string, datatype string, value interface{}, entityID string) {
+	if postLayer.logger == nil { // CreatePayload and CreateUpsertBulk are exercised without one
+		return
+	}
+	postLayer.logger.Warnf("%s value %v is outside the %s range, writing NULL for entity %s", fieldName, value, datatype, entityID)
 }
 
 func getSqlNull(datatype string) any {
@@ -310,7 +362,11 @@ func getSqlNull(datatype string) any {
 		return sql.RawBytes{}
 	}
 }
-func (postLayer *PostLayer) CreateUpsertBulk(entities []*Entity, fields []*conf.FieldMapping, queryDel string, idColumn string, timeZone string, tableName string) string {
+func (postLayer *PostLayer) CreateUpsertBulk(entities []*Entity, fields []*conf.FieldMapping, queryDel string, idColumn string, timeZone string, tableName string) (string, error) {
+	location, err := loadLocation(timeZone)
+	if err != nil {
+		return "", err
+	}
 	buildQuery := ""
 	for _, post := range entities {
 		if !strings.ContainsAny(post.ID, ":") {
@@ -339,7 +395,7 @@ func (postLayer *PostLayer) CreateUpsertBulk(entities []*Entity, fields []*conf.
 					if !postLayer.PostRepo.PostTableDef.NullEmptyColumnValues {
 						continue // TODO:Need to fail properly when this happens
 					}
-					columnValues += cast.ToString(getSqlNull(datatype)) + ","
+					columnValues += "NULL," // raw SQL, so the null is the literal, not a stringified sql.Null*
 				} else {
 					switch datatype {
 					case "BIT":
@@ -354,13 +410,16 @@ func (postLayer *PostLayer) CreateUpsertBulk(entities []*Entity, fields []*conf.
 						columnValues += fmt.Sprintf("%f", value) + ","
 					case "DATETIME", "DATETIME2":
 						t, err := time.Parse(time.RFC3339, fmt.Sprintf("%s", value))
-						var location *time.Location
-						location, _ = time.LoadLocation(timeZone)
 						if err != nil {
-							return ""
+							return "", parseError(field.FieldName, datatype, value, post.ID, err)
 						}
-						time := fmt.Sprintf("%s", t.In(location).Format("2006-01-02T15:04:05"))
-						columnValues += "'" + time + "',"
+						ts := t.In(location)
+						if !datetimeInRange(datatype, ts) {
+							postLayer.warnOutOfRange(field.FieldName, datatype, value, post.ID)
+							columnValues += "NULL,"
+						} else {
+							columnValues += "'" + ts.Format("2006-01-02T15:04:05") + "',"
+						}
 					case "DATETIMEOFFSET":
 						columnValues += "'" + fmt.Sprintf("%s", value) + "',"
 					default: // all other types can be sent as string
@@ -402,13 +461,10 @@ func (postLayer *PostLayer) CreateUpsertBulk(entities []*Entity, fields []*conf.
 						rowId += fmt.Sprintf("%f", value)
 					case "DATETIME", "DATETIME2":
 						t, err := time.Parse(time.RFC3339, fmt.Sprintf("%s", value))
-						var location *time.Location
-						location, _ = time.LoadLocation(timeZone)
 						if err != nil {
-							return ""
+							return "", parseError(field.FieldName, datatype, value, post.ID, err)
 						}
-						time := fmt.Sprintf("%s", t.In(location).Format("2006-01-02T15:04:05"))
-						rowId += "'" + time + "',"
+						rowId += "'" + t.In(location).Format("2006-01-02T15:04:05") + "',"
 					case "DATETIMEOFFSET":
 						rowId += "'" + fmt.Sprintf("%s", value) + "',"
 					default: // all other types can be sent as string
@@ -419,7 +475,7 @@ func (postLayer *PostLayer) CreateUpsertBulk(entities []*Entity, fields []*conf.
 			buildQuery += queryDel + rowId + ";"
 		}
 	}
-	return buildQuery
+	return buildQuery, nil
 }
 
 func (postLayer *PostLayer) GetTableDefinition(datasetName string) *conf.PostMapping {

--- a/internal/layers/postlayer_test.go
+++ b/internal/layers/postlayer_test.go
@@ -1,6 +1,7 @@
 package layers_test
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"github.com/franela/goblin"
@@ -10,6 +11,29 @@ import (
 	"strings"
 	"testing"
 )
+
+// loadPostLayer builds a PostLayer around the first postMapping of a config fixture, plus its entities.
+func loadPostLayer(cfgPath string, dataPath string) (*layers.PostLayer, []*layers.Entity) {
+	postM, err := os.ReadFile(cfgPath)
+	if err != nil {
+		panic(err)
+	}
+	datalayer := conf.Datalayer{}
+	if err := json.Unmarshal(postM, &datalayer); err != nil {
+		panic(err)
+	}
+	file, err := os.ReadFile(dataPath)
+	if err != nil {
+		panic(err)
+	}
+	var entities []*layers.Entity
+	if err := json.Unmarshal(file, &entities); err != nil {
+		panic(err)
+	}
+	pl := &layers.PostLayer{PostRepo: &layers.PostRepository{}}
+	pl.PostRepo.PostTableDef = datalayer.PostMappings[0]
+	return pl, entities
+}
 
 func TestUpsertBulk(t *testing.T) {
 	g := goblin.Goblin(t)
@@ -59,7 +83,8 @@ func TestUpsertBulk(t *testing.T) {
 				PostRepo: &layers.PostRepository{},
 			}
 			pl.PostRepo.PostTableDef = datalayer.PostMappings[0]
-			query := (*layers.PostLayer).CreateUpsertBulk(pl, entities, pl.PostRepo.PostTableDef.FieldMappings, "DELETE FROM test WHERE Id = ", "Id", "Europe/Oslo", "test")
+			query, err := (*layers.PostLayer).CreateUpsertBulk(pl, entities, pl.PostRepo.PostTableDef.FieldMappings, "DELETE FROM test WHERE Id = ", "Id", "Europe/Oslo", "test")
+			g.Assert(err).IsNil()
 			g.Assert(query).Eql("DELETE FROM test WHERE Id = 'a:1';DELETE FROM test WHERE Id = 'a:2';DELETE FROM test WHERE Id = 'a:3';INSERT INTO test (Id, Column_Int, Column_Tinyint, Column_Smallint, Column_Bit, Column_Float, Column_Datetime, Column_Datetime2, Column_DatetimeOffset, Column_Varchar, Column_Decimal, Column_Numeric, Column_Date ) VALUES ( 'a:3',12344556,13,41,0,7.990000,'2023-01-01T01:01:01','2023-01-01T00:01:01','2023-01-01T01:01:01+02:00','b:string',90.090000,211.110000,'2023-01-01' );DELETE FROM test WHERE Id = 'a:4';INSERT INTO test (Id, Column_Int, Column_Tinyint, Column_Smallint, Column_Bit, Column_Float, Column_Varchar, Column_Decimal, Column_Numeric ) VALUES ( 'a:4',12344556,13,41,0,7.990000,'b:string',90.090000,211.110000 );")
 			resultSlice := strings.Split(query, ";")
 
@@ -72,6 +97,126 @@ func TestUpsertBulk(t *testing.T) {
 			g.Assert(resultSlice[4]).Eql("DELETE FROM test WHERE Id = 'a:4'")
 			g.Assert(resultSlice[5]).Eql("INSERT INTO test (Id, Column_Int, Column_Tinyint, Column_Smallint, Column_Bit, Column_Float, Column_Varchar, Column_Decimal, Column_Numeric ) VALUES ( 'a:4',12344556,13,41,0,7.990000,'b:string',90.090000,211.110000 )")
 
+		})
+		g.It("Should emit NULL literals for missing values when nullEmptyColumnValues is set", func() {
+			postM, err := os.ReadFile("../../resources/test/test-upsertbulk.json")
+			if err != nil {
+				fmt.Print(err)
+			}
+			datalayer := conf.Datalayer{}
+			if err := json.Unmarshal(postM, &datalayer); err != nil {
+				fmt.Print(err)
+			}
+			file, err := os.ReadFile("../../resources/test/data/test1.json")
+			if err != nil {
+				fmt.Print(err)
+			}
+			var entities []*layers.Entity
+			if err := json.Unmarshal(file, &entities); err != nil {
+				fmt.Println(err)
+			}
+			pl := &layers.PostLayer{
+				PostRepo: &layers.PostRepository{},
+			}
+			pl.PostRepo.PostTableDef = datalayer.PostMappings[0]
+			pl.PostRepo.PostTableDef.NullEmptyColumnValues = true
+
+			// a:4 is missing the datetime and date columns
+			query, err := (*layers.PostLayer).CreateUpsertBulk(pl, entities[4:5], pl.PostRepo.PostTableDef.FieldMappings, "DELETE FROM test WHERE Id = ", "Id", "Europe/Oslo", "test")
+			g.Assert(err).IsNil()
+			g.Assert(query).Eql("DELETE FROM test WHERE Id = 'a:4';INSERT INTO test (Id, Column_Int, Column_Tinyint, Column_Smallint, Column_Bit, Column_Float, Column_Datetime, Column_Datetime2, Column_DatetimeOffset, Column_Varchar, Column_Decimal, Column_Numeric, Column_Date ) VALUES ( 'a:4',12344556,13,41,0,7.990000,NULL,NULL,NULL,'b:string',90.090000,211.110000,NULL );")
+		})
+		g.It("Should emit NULL for datetimes outside the target column range", func() {
+			postM, err := os.ReadFile("../../resources/test/test-upsertbulk.json")
+			if err != nil {
+				fmt.Print(err)
+			}
+			datalayer := conf.Datalayer{}
+			if err := json.Unmarshal(postM, &datalayer); err != nil {
+				fmt.Print(err)
+			}
+			file, err := os.ReadFile("../../resources/test/data/test-datetime-range.json")
+			if err != nil {
+				fmt.Print(err)
+			}
+			var entities []*layers.Entity
+			if err := json.Unmarshal(file, &entities); err != nil {
+				fmt.Println(err)
+			}
+			pl := &layers.PostLayer{
+				PostRepo: &layers.PostRepository{},
+			}
+			pl.PostRepo.PostTableDef = datalayer.PostMappings[0]
+
+			query, err := (*layers.PostLayer).CreateUpsertBulk(pl, entities, pl.PostRepo.PostTableDef.FieldMappings, "DELETE FROM test WHERE Id = ", "Id", "Europe/Oslo", "test")
+			g.Assert(err).IsNil()
+			resultSlice := strings.Split(query, ";")
+
+			// DATETIME starts at 1753-01-01, so the zero time is out of range; DATETIME2 starts at 0001-01-01 and keeps it
+			g.Assert(resultSlice[1]).Eql("INSERT INTO test (Id, Column_Datetime, Column_Datetime2 ) VALUES ( 'a:5',NULL,'0001-01-01T00:53:28' )")
+			// both types end at 9999-12-31, and the Oslo offset pushes this past that
+			g.Assert(resultSlice[3]).Eql("INSERT INTO test (Id, Column_Datetime, Column_Datetime2 ) VALUES ( 'a:6',NULL,NULL )")
+		})
+		g.It("Should null out-of-range datetimes in the parameterised payload", func() {
+			postM, err := os.ReadFile("../../resources/test/test-upsertbulk.json")
+			if err != nil {
+				fmt.Print(err)
+			}
+			datalayer := conf.Datalayer{}
+			if err := json.Unmarshal(postM, &datalayer); err != nil {
+				fmt.Print(err)
+			}
+			file, err := os.ReadFile("../../resources/test/data/test-datetime-range.json")
+			if err != nil {
+				fmt.Print(err)
+			}
+			var entities []*layers.Entity
+			if err := json.Unmarshal(file, &entities); err != nil {
+				fmt.Println(err)
+			}
+			pl := &layers.PostLayer{
+				PostRepo: &layers.PostRepository{},
+			}
+			pl.PostRepo.PostTableDef = datalayer.PostMappings[0]
+
+			// a:5 carries the zero time in both a DATETIME and a DATETIME2 column
+			payload, err := (*layers.PostLayer).CreatePayload(pl, entities[1], pl.PostRepo.PostTableDef.FieldMappings)
+			g.Assert(err).IsNil()
+			g.Assert(len(payload)).Eql(3)
+			g.Assert(payload[0]).Eql("a:5")
+			g.Assert(payload[1]).Eql(sql.NullTime{})
+			g.Assert(payload[2]).IsNotNil()
+		})
+		g.It("Should return an error rather than exiting when a payload datetime cannot be parsed", func() {
+			pl, entities := loadPostLayer("../../resources/test/test-upsertbulk.json", "../../resources/test/data/test-datetime-invalid.json")
+
+			payload, err := (*layers.PostLayer).CreatePayload(pl, entities[1], pl.PostRepo.PostTableDef.FieldMappings)
+			g.Assert(err == nil).IsFalse()
+			g.Assert(payload).IsNil()
+		})
+		g.It("Should return an error rather than exiting when a delete id datetime cannot be parsed", func() {
+			pl, entities := loadPostLayer("../../resources/test/test-datetime-idcolumn.json", "../../resources/test/data/test-datetime-invalid.json")
+			s := entities[1].StripProps()
+
+			delQueue, err := (*layers.PostLayer).CustomDelete(pl, entities[1], pl.PostRepo.PostTableDef.FieldMappings, s, "", "Europe/Oslo", "DELETE FROM test WHERE Column_Datetime = ")
+			g.Assert(err == nil).IsFalse()
+			g.Assert(delQueue).Eql("")
+		})
+		g.It("Should return an error when a bulk statement datetime cannot be parsed", func() {
+			pl, entities := loadPostLayer("../../resources/test/test-upsertbulk.json", "../../resources/test/data/test-datetime-invalid.json")
+
+			query, err := (*layers.PostLayer).CreateUpsertBulk(pl, entities, pl.PostRepo.PostTableDef.FieldMappings, "DELETE FROM test WHERE Id = ", "Id", "Europe/Oslo", "test")
+			g.Assert(err == nil).IsFalse()
+			g.Assert(strings.Contains(err.Error(), "Column_Datetime")).IsTrue()
+			g.Assert(query).Eql("")
+		})
+		g.It("Should return an error naming the timezone when it is unknown", func() {
+			pl, entities := loadPostLayer("../../resources/test/test-upsertbulk.json", "../../resources/test/data/test-datetime-range.json")
+
+			query, err := (*layers.PostLayer).CreateUpsertBulk(pl, entities, pl.PostRepo.PostTableDef.FieldMappings, "DELETE FROM test WHERE Id = ", "Id", "Europe/Osloo", "test")
+			g.Assert(err == nil).IsFalse()
+			g.Assert(strings.Contains(err.Error(), "Europe/Osloo")).IsTrue()
+			g.Assert(query).Eql("")
 		})
 		g.It("Should create user defined statement", func() {
 			postM, err := os.ReadFile("../../resources/test/test-customquery.json")
@@ -98,9 +243,12 @@ func TestUpsertBulk(t *testing.T) {
 			s2 := entities[2].StripProps()
 			s3 := entities[3].StripProps()
 
-			delTest1 := (*layers.PostLayer).CustomDelete(pl, entities[1], pl.PostRepo.PostTableDef.FieldMappings, s1, "", "", "DELETE FROM test WHERE Id = ")
-			delTest2 := (*layers.PostLayer).CustomDelete(pl, entities[2], pl.PostRepo.PostTableDef.FieldMappings, s2, "", "", "DELETE FROM test WHERE Id = ")
-			delTest3 := (*layers.PostLayer).CustomDelete(pl, entities[3], pl.PostRepo.PostTableDef.FieldMappings, s3, "", "", "DELETE FROM test WHERE Id = ")
+			delTest1, errDel1 := (*layers.PostLayer).CustomDelete(pl, entities[1], pl.PostRepo.PostTableDef.FieldMappings, s1, "", "", "DELETE FROM test WHERE Id = ")
+			delTest2, errDel2 := (*layers.PostLayer).CustomDelete(pl, entities[2], pl.PostRepo.PostTableDef.FieldMappings, s2, "", "", "DELETE FROM test WHERE Id = ")
+			delTest3, errDel3 := (*layers.PostLayer).CustomDelete(pl, entities[3], pl.PostRepo.PostTableDef.FieldMappings, s3, "", "", "DELETE FROM test WHERE Id = ")
+			g.Assert(errDel1).IsNil()
+			g.Assert(errDel2).IsNil()
+			g.Assert(errDel3).IsNil()
 			g.Assert(delTest1).Eql("DELETE FROM test WHERE Id = 'a:1';")
 			g.Assert(delTest2).Eql("DELETE FROM test WHERE Id = 'a:2';")
 			g.Assert(delTest3).Eql("DELETE FROM test WHERE Id = 'a:3';")

--- a/internal/layers/postlayer_test.go
+++ b/internal/layers/postlayer_test.go
@@ -148,13 +148,15 @@ func TestUpsertBulk(t *testing.T) {
 			}
 			pl.PostRepo.PostTableDef = datalayer.PostMappings[0]
 
-			query, err := (*layers.PostLayer).CreateUpsertBulk(pl, entities, pl.PostRepo.PostTableDef.FieldMappings, "DELETE FROM test WHERE Id = ", "Id", "Europe/Oslo", "test")
+			// Etc/GMT-1 is a fixed +01:00 zone with no LMT entry. A named zone such as Europe/Oslo would
+			// resolve pre-1895 dates through local mean time, whose offset differs between tzdata releases.
+			query, err := (*layers.PostLayer).CreateUpsertBulk(pl, entities, pl.PostRepo.PostTableDef.FieldMappings, "DELETE FROM test WHERE Id = ", "Id", "Etc/GMT-1", "test")
 			g.Assert(err).IsNil()
 			resultSlice := strings.Split(query, ";")
 
 			// DATETIME starts at 1753-01-01, so the zero time is out of range; DATETIME2 starts at 0001-01-01 and keeps it
-			g.Assert(resultSlice[1]).Eql("INSERT INTO test (Id, Column_Datetime, Column_Datetime2 ) VALUES ( 'a:5',NULL,'0001-01-01T00:53:28' )")
-			// both types end at 9999-12-31, and the Oslo offset pushes this past that
+			g.Assert(resultSlice[1]).Eql("INSERT INTO test (Id, Column_Datetime, Column_Datetime2 ) VALUES ( 'a:5',NULL,'0001-01-01T01:00:00' )")
+			// both types end at 9999-12-31, and the +01:00 offset pushes this past that
 			g.Assert(resultSlice[3]).Eql("INSERT INTO test (Id, Column_Datetime, Column_Datetime2 ) VALUES ( 'a:6',NULL,NULL )")
 		})
 		g.It("Should null out-of-range datetimes in the parameterised payload", func() {

--- a/resources/test/data/test-datetime-invalid.json
+++ b/resources/test/data/test-datetime-invalid.json
@@ -1,0 +1,18 @@
+[
+    {
+        "id": "@context",
+        "namespaces": {
+            "a": "http://data/base",
+            "b": "http://external/base"
+        }
+    },
+    {
+        "id": "a:7",
+        "deleted": false,
+        "recorded": 12351591859,
+        "props": {
+            "a:Id": "a:7",
+            "b:Column_Datetime": "not-a-datetime"
+        }
+    }
+]

--- a/resources/test/data/test-datetime-range.json
+++ b/resources/test/data/test-datetime-range.json
@@ -1,0 +1,29 @@
+[
+    {
+        "id": "@context",
+        "namespaces": {
+            "a": "http://data/base",
+            "b": "http://external/base"
+        }
+    },
+    {
+        "id": "a:5",
+        "deleted": false,
+        "recorded": 12351591859,
+        "props": {
+            "a:Id": "a:5",
+            "b:Column_Datetime": "0001-01-01T00:00:00Z",
+            "b:Column_Datetime2": "0001-01-01T00:00:00Z"
+        }
+    },
+    {
+        "id": "a:6",
+        "deleted": false,
+        "recorded": 12351591859,
+        "props": {
+            "a:Id": "a:6",
+            "b:Column_Datetime": "9999-12-31T23:59:59Z",
+            "b:Column_Datetime2": "9999-12-31T23:59:59Z"
+        }
+    }
+]

--- a/resources/test/test-datetime-idcolumn.json
+++ b/resources/test/test-datetime-idcolumn.json
@@ -1,0 +1,27 @@
+{
+    "baseNameSpace": "http://data.mimiro.io/test/",
+    "baseUri": "http://data.mimiro.io/test/",
+    "database": "MYDB1",
+    "databaseServer": "localhost",
+    "id": "test",
+    "password": "Test1234",
+    "user": "sa",
+    "port": "1433",
+    "postMappings": [
+        {
+            "datasetName": "test.Sql",
+            "fieldMappings": [
+                {
+                    "fieldName": "Column_Datetime",
+                    "order": 1,
+                    "dataType": "DATETIME"
+                }
+            ],
+            "query": "upsertBulk",
+            "tableName": "test",
+            "batchSize": 10000,
+            "workers": 20,
+            "timezone": "Europe/Oslo",
+            "idColumn": "Column_Datetime"
+        }]
+}


### PR DESCRIPTION
fixing issue where the datetime that comes out of go (0001-01-01) ends up outside the mssql range when timezones are added.